### PR TITLE
Add lzo-rle algo option

### DIFF
--- a/zramen
+++ b/zramen
@@ -60,6 +60,7 @@ Commands:
 Algorithm
   Run zramctl --help to see a list of acceptable algorithms:
   | lzo
+  | lzo-rle
   | lz4
   | lz4hc
   | deflate
@@ -142,7 +143,7 @@ set -- "${_POSITIONAL[@]}"
 _algorithm="${_algorithm:-$ZRAM_COMP_ALGORITHM}"
 case "$_algorithm" in
   # proper algo chosen, no action necessary
-  lzo|lz4|lz4hc|deflate|842)
+  lzo|lzo-rle|lz4|lz4hc|deflate|842)
     ;;
   # improper algo chosen, reset to default
   *)


### PR DESCRIPTION
lzo-rle was made [the default](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ce82f19fd5809f0cf87ea9f753c5cc65ca0673d6) for the zram module in Linux 5.1.