### PR TITLE
Allow sizes higher than 100%

### DIFF
--- a/zramen
+++ b/zramen
@@ -175,8 +175,8 @@ _priority=${_priority:-$ZRAM_PRIORITY}
 _size=${_size:-$ZRAM_SIZE}
 [[ $_size -gt 0 ]] \
   || _size=$SIZE
-[[ $_size -le 100 ]] \
-  || _size=100
+[[ $_size -le 250 ]] \
+  || _size=250
 
 # sanitize max size input
 _max_size=${_max_size:-$ZRAM_MAX_SIZE}


### PR DESCRIPTION
zram can be a high size than 100%, since the size is the size of the uncompressed zram device. As detailed here: 

https://wiki.archlinux.org/title/Zram

> As discussed above, when configuring zram, the size of the zram device controls the maximum uncompressed amount of data it can store, not the maximum compressed size. You can configure the zram's size to be equal to or even greater than your system's physical RAM capacity, as long as the compressed size on physical RAM will not exceed your system's physical RAM capacity.

I was originally using zram with a size of 250% back on archlinux, It had to be that big because I needed that much memory when using foobar2000 with wine for converting my entire music library as for some reason it seems to load my entire music library to mem first. I now moved to artix and installed zramen and ran into this limitation. 

 